### PR TITLE
Fix typo in `CreateDbIfNotExists`

### DIFF
--- a/ContosoPizza/Program.cs
+++ b/ContosoPizza/Program.cs
@@ -28,6 +28,6 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-// Add the CreateDbInNotExists method call
+// Add the CreateDbIfNotExists method call
 
 app.Run();


### PR DESCRIPTION
Fixes a small typo in a comment.

Will need to update the text at https://docs.microsoft.com/en-us/learn/modules/persist-data-ef-core/4-interacting-data if this is merged:

> 5. In _Program.cs_, replace `// Add the CreateDbInNotExists method call` comment with the following code: